### PR TITLE
Added a roundtrip test for CrichtonRepresentor and extracted ISerializer

### DIFF
--- a/src/Crichton.Representors/Crichton.Representors.csproj
+++ b/src/Crichton.Representors/Crichton.Representors.csproj
@@ -38,6 +38,7 @@
     <Compile Include="CrichtonTransitionAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serializers\HalSerializer.cs" />
+    <Compile Include="Serializers\ISerializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Crichton.Representors/Serializers/HalSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HalSerializer.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors.Serializers
 {
-    public class HalSerializer
+    public class HalSerializer : ISerializer
     {
         public string Serialize(CrichtonRepresentor representor)
         {

--- a/src/Crichton.Representors/Serializers/ISerializer.cs
+++ b/src/Crichton.Representors/Serializers/ISerializer.cs
@@ -1,0 +1,8 @@
+﻿namespace Crichton.Representors.Serializers
+{
+    public interface ISerializer
+    {
+        string Serialize(CrichtonRepresentor representor);
+        CrichtonRepresentor Deserialize(string message);
+    }
+}

--- a/tests/Crichton.Representors.Tests/CrichtonRepresentorTests.cs
+++ b/tests/Crichton.Representors.Tests/CrichtonRepresentorTests.cs
@@ -41,5 +41,17 @@ namespace Crichton.Representors.Tests
             }
 
         }
+
+        [Test]
+        public void SetAttributes_RoundTrip()
+        {
+            var expected = Fixture.Create<ExampleDataObject>();
+            
+            sut.SetAttributesFromObject(expected);
+
+            var result = sut.ToObject<ExampleDataObject>();
+
+            result.ShouldBeEquivalentTo(expected, options => options.IncludingAllDeclaredProperties());
+        }
     }
 }


### PR DESCRIPTION
- Added an extra test to make sure CrichtonRepresentor can recreate your domain object
- Extracted ISerializer from HalSerializer (this interface is not final)

@fosdev @brutski @sheavalentine-mdsol Please merge
