### PR TITLE
Refactor to use IRepresentorBuilder

### DIFF
--- a/src/Crichton.Representors/Crichton.Representors.csproj
+++ b/src/Crichton.Representors/Crichton.Representors.csproj
@@ -37,6 +37,7 @@
     <Compile Include="CrichtonTransition.cs" />
     <Compile Include="CrichtonTransitionAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RepresentorBuilder.cs" />
     <Compile Include="Serializers\HalSerializer.cs" />
     <Compile Include="Serializers\ISerializer.cs" />
   </ItemGroup>

--- a/src/Crichton.Representors/Crichton.Representors.csproj
+++ b/src/Crichton.Representors/Crichton.Representors.csproj
@@ -36,6 +36,7 @@
     <Compile Include="CrichtonRepresentor.cs" />
     <Compile Include="CrichtonTransition.cs" />
     <Compile Include="CrichtonTransitionAttribute.cs" />
+    <Compile Include="IRepresentorBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepresentorBuilder.cs" />
     <Compile Include="Serializers\HalSerializer.cs" />

--- a/src/Crichton.Representors/Crichton.Representors.csproj
+++ b/src/Crichton.Representors/Crichton.Representors.csproj
@@ -38,6 +38,7 @@
     <Compile Include="CrichtonTransitionAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serializers\HalSerializer.cs" />
+    <Compile Include="Serializers\ISerializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Crichton.Representors/IRepresentorBuilder.cs
+++ b/src/Crichton.Representors/IRepresentorBuilder.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json.Linq;
+
+namespace Crichton.Representors
+{
+    public interface IRepresentorBuilder
+    {
+        CrichtonRepresentor ToRepresentor();
+        void SetSelfLink(string self);
+        void SetAttributes(JObject attributes);
+        void SetAttributesFromObject(object data);
+        void AddTransition(string rel, string uri);
+    }
+}

--- a/src/Crichton.Representors/RepresentorBuilder.cs
+++ b/src/Crichton.Representors/RepresentorBuilder.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors
 {
-    public class RepresentorBuilder
+    public class RepresentorBuilder : IRepresentorBuilder
     {
         private readonly CrichtonRepresentor representor;
 

--- a/src/Crichton.Representors/RepresentorBuilder.cs
+++ b/src/Crichton.Representors/RepresentorBuilder.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace Crichton.Representors
+{
+    public class RepresentorBuilder
+    {
+        private readonly CrichtonRepresentor representor;
+
+        public RepresentorBuilder()
+        {
+            representor = new CrichtonRepresentor();
+        }
+
+        public CrichtonRepresentor ToRepresentor()
+        {
+            return representor;
+        }
+
+        public void SetSelfLink(string self)
+        {
+            representor.SelfLink = self;
+        }
+
+        public void SetAttributes(JObject attributes)
+        {
+            representor.Attributes = attributes;
+        }
+
+        public void SetAttributesFromObject(object data)
+        {
+            representor.Attributes = JObject.FromObject(data);
+        }
+
+        public void AddTransition(string rel, string uri)
+        {
+            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri});
+        }
+    }
+}

--- a/src/Crichton.Representors/Serializers/HalSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HalSerializer.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors.Serializers
 {
-    public class HalSerializer
+    public class HalSerializer : ISerializer
     {
         public string Serialize(CrichtonRepresentor representor)
         {

--- a/src/Crichton.Representors/Serializers/HalSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HalSerializer.cs
@@ -50,32 +50,28 @@ namespace Crichton.Representors.Serializers
             }
         }
 
-        public CrichtonRepresentor Deserialize(string message)
+        public void DeserializeToBuilder(string message, IRepresentorBuilder builder)
         {
-            var representor = new CrichtonRepresentor();
-
             var document = JObject.Parse(message);
 
-            SetSelfLinkIfPresent(representor, document);
+            SetSelfLinkIfPresent(document, builder);
 
-            CreateTransitions(document, representor);
+            CreateTransitions(document, builder);
 
-            // set representor attributes to be that of root properties in message
-            representor.Attributes = JObject.Parse(message);
-
-            return representor;
+            // set builder attributes to be that of root properties in message
+            builder.SetAttributes(JObject.Parse(message));
         }
 
-        private static void SetSelfLinkIfPresent(CrichtonRepresentor representor, JObject document)
+        private static void SetSelfLinkIfPresent(JObject document, IRepresentorBuilder builder)
         {
             if (document["_links"] == null) return;
             if (document["_links"]["self"] == null) return;
             if (document["_links"]["self"]["href"] == null) return;
 
-            representor.SelfLink = document["_links"]["self"]["href"].Value<string>();
+            builder.SetSelfLink(document["_links"]["self"]["href"].Value<string>());
         }
 
-        private static void CreateTransitions(JObject document, CrichtonRepresentor representor)
+        private static void CreateTransitions(JObject document, IRepresentorBuilder builder)
         {
             if (document["_links"] == null) return;
 
@@ -89,11 +85,7 @@ namespace Crichton.Representors.Serializers
                     if (document["_links"][rel]["href"] != null)
                     {
                         // single link for this rel only
-                        representor.Transitions.Add(new CrichtonTransition
-                        {
-                            Rel = rel,
-                            Uri = document["_links"][rel]["href"].Value<string>()
-                        });
+                        builder.AddTransition(rel, document["_links"][rel]["href"].Value<string>());
                     }
                 }
                 else
@@ -103,11 +95,7 @@ namespace Crichton.Representors.Serializers
                     {
                         if (link["href"] != null)
                         {
-                            representor.Transitions.Add(new CrichtonTransition
-                            {
-                                Rel = rel,
-                                Uri = link["href"].Value<string>()
-                            });
+                            builder.AddTransition(rel, link["href"].Value<string>());
                         }
                     }
                 }

--- a/src/Crichton.Representors/Serializers/ISerializer.cs
+++ b/src/Crichton.Representors/Serializers/ISerializer.cs
@@ -3,6 +3,6 @@
     public interface ISerializer
     {
         string Serialize(CrichtonRepresentor representor);
-        CrichtonRepresentor Deserialize(string message);
+        void DeserializeToBuilder(string message, IRepresentorBuilder builder);
     }
 }

--- a/src/Crichton.Representors/Serializers/ISerializer.cs
+++ b/src/Crichton.Representors/Serializers/ISerializer.cs
@@ -1,0 +1,8 @@
+﻿namespace Crichton.Representors.Serializers
+{
+    public interface ISerializer
+    {
+        string Serialize(CrichtonRepresentor representor);
+        CrichtonRepresentor Deserialize(string message);
+    }
+}

--- a/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
+++ b/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="CrichtonRepresentorTests.cs" />
     <Compile Include="ExampleDataObject.cs" />
+    <Compile Include="RepresentorBuilderTests.cs" />
     <Compile Include="Serializers\HalSerializerTests.cs" />
     <Compile Include="TestWithFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/Crichton.Representors.Tests/CrichtonRepresentorTests.cs
+++ b/tests/Crichton.Representors.Tests/CrichtonRepresentorTests.cs
@@ -41,5 +41,17 @@ namespace Crichton.Representors.Tests
             }
 
         }
+
+        [Test]
+        public void SetAttributes_RoundTrip()
+        {
+            var expected = Fixture.Create<ExampleDataObject>();
+            
+            sut.SetAttributesFromObject(expected);
+
+            var result = sut.ToObject<ExampleDataObject>();
+
+            result.ShouldBeEquivalentTo(expected, options => options.IncludingAllDeclaredProperties());
+        }
     }
 }

--- a/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
+++ b/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Crichton.Representors.Tests
+{
+    public class RepresentorBuilderTests : TestWithFixture
+    {
+        private RepresentorBuilder sut;
+
+        [SetUp]
+        public void Init()
+        {
+            sut = new RepresentorBuilder();
+            Fixture = GetFixture();
+        }
+
+        [Test]
+        public void ToRepresentor_ReturnsARepresentor()
+        {
+            var result = sut.ToRepresentor();
+
+            Assert.IsInstanceOf<CrichtonRepresentor>(result);
+        }
+
+        [Test]
+        public void SetSelfLink_SetsSelfLink()
+        {
+            var self = Fixture.Create<string>();
+
+            sut.SetSelfLink(self);
+            var result = sut.ToRepresentor();
+
+            Assert.AreEqual(self, result.SelfLink);
+        }
+
+        [Test]
+        public void SetAttributes_SetsRepresentorAttributes()
+        {
+            var attributes = new JObject();
+            sut.SetAttributes(attributes);
+            var result = sut.ToRepresentor();
+
+            Assert.AreEqual(attributes, result.Attributes);
+        }
+
+        [Test]
+        public void SetAttributesFromObject_SetsAttributes()
+        {
+            var example = Fixture.Create<ExampleDataObject>();
+            var expectedJObject = JObject.FromObject(example);
+
+            sut.SetAttributesFromObject(example);
+            var result = sut.ToRepresentor();
+
+            foreach (var property in expectedJObject.Properties())
+            {
+                Assert.AreEqual(expectedJObject[property.Name], result.Attributes[property.Name]);
+            }
+
+        }
+
+        [Test]
+        public void AddTransition_CorrectlyAddsSimpleTransition()
+        {
+            var rel = Fixture.Create<string>();
+            var uri = Fixture.Create<string>();
+
+            sut.AddTransition(rel, uri);
+            var result = sut.ToRepresentor();
+
+            result.Transitions.Should().Contain(t => t.Rel == rel && t.Uri == uri);
+
+        }
+    
+    }
+}

--- a/tests/Crichton.Representors.Tests/Serializers/HalSerializerTests.cs
+++ b/tests/Crichton.Representors.Tests/Serializers/HalSerializerTests.cs
@@ -161,8 +161,6 @@ namespace Crichton.Representors.Tests.Serializers
 
             builder.AssertWasCalled(b => b.SetAttributes(Arg<JObject>.Matches(j => j["id"].Value<string>() == id && j["int_id"].Value<int>() == intId)));
 
-            //Assert.AreEqual(id, result.Attributes["id"].Value<string>());
-            //Assert.AreEqual(intId, result.Attributes["int_id"].Value<int>());
         }
 
         [Test]
@@ -185,8 +183,6 @@ namespace Crichton.Representors.Tests.Serializers
             sut.DeserializeToBuilder(json, builder);
 
             builder.AssertWasCalled(b => b.AddTransition(rel, href));
-
-            // result.Transitions.Should().Contain(t => t.Rel == rel && t.Uri == href);
         }
 
         [Test]
@@ -211,9 +207,6 @@ namespace Crichton.Representors.Tests.Serializers
 
             builder.AssertWasCalled(b => b.AddTransition(rel, href));
             builder.AssertWasCalled(b => b.AddTransition(rel, href2));
-
-            //result.Transitions.Should().Contain(t => t.Rel == rel && t.Uri == href);
-            //result.Transitions.Should().Contain(t => t.Rel == rel && t.Uri == href2);
         }
 
         [Test]


### PR DESCRIPTION
Deserialize now uses IRepresentorBuilder instead of building a CrichtonRepresentor object directly. Tests have been amended to reflect this change.

@fosdev this should hopefully reflect what we were talking about yesterday
@brutski @sheavalentine-mdsol Would appreciate a review and merge. Again, all of this is subject to change or refactor later and nothing is set in stone yet as I am just fleshing out the design.
