### PR TITLE
Round trip tests for HalSerializer and "title" support for Links/Transitions

### DIFF
--- a/src/Crichton.Representors/CrichtonTransition.cs
+++ b/src/Crichton.Representors/CrichtonTransition.cs
@@ -8,6 +8,7 @@ namespace Crichton.Representors
         public string Uri { get; set; }
         public string TemplatedUri { get; set; }
         public string InterfaceMethod { get; set; }
+        public string Title { get; set; }
         public IList<CrichtonTransitionAttribute> Attributes { get; set; } 
     }
 }

--- a/src/Crichton.Representors/IRepresentorBuilder.cs
+++ b/src/Crichton.Representors/IRepresentorBuilder.cs
@@ -9,5 +9,6 @@ namespace Crichton.Representors
         void SetAttributes(JObject attributes);
         void SetAttributesFromObject(object data);
         void AddTransition(string rel, string uri);
+        void AddTransition(string rel, string uri, string title);
     }
 }

--- a/src/Crichton.Representors/RepresentorBuilder.cs
+++ b/src/Crichton.Representors/RepresentorBuilder.cs
@@ -37,7 +37,12 @@ namespace Crichton.Representors
 
         public void AddTransition(string rel, string uri)
         {
-            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri});
+            AddTransition(rel, uri, null);
+        }
+
+        public void AddTransition(string rel, string uri, string title)
+        {
+            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri, Title = title});
         }
     }
 }

--- a/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
+++ b/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="CrichtonRepresentorTests.cs" />
     <Compile Include="ExampleDataObject.cs" />
+    <Compile Include="Integration\HalSerializerRoundTrips.cs" />
     <Compile Include="RepresentorBuilderTests.cs" />
     <Compile Include="Serializers\HalSerializerTests.cs" />
     <Compile Include="TestWithFixture.cs" />

--- a/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
+++ b/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Crichton.Representors.Serializers;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using Rhino.Mocks;
+
+namespace Crichton.Representors.Tests.Integration
+{
+    public class HalSerializerRoundTrips : TestWithFixture
+    {
+        private HalSerializer serializer;
+        private RepresentorBuilder builder;
+
+        [SetUp]
+        public void Init()
+        {
+            serializer = new HalSerializer();
+            builder = new RepresentorBuilder();
+            Fixture = GetFixture();
+        }
+
+        private const string SelfLinkOnly = @"{
+            '_links': {
+                'self': { 'href': '/example_resource' }
+            }
+        }";
+
+        [Test]
+        public void SelfLinkOnly_RoundTrip()
+        {
+            TestRoundTripJson(SelfLinkOnly);
+        }
+
+        private const string MultipleLinksSameRelation = @"
+        {
+            '_links': {
+              'items': [{
+                  'href': '/first_item'
+              },{
+                  'href': '/second_item'
+              }]
+            }
+        }";
+
+        [Test]
+        public void MultipleLinksSameRelation_RoundTrip()
+        {
+            TestRoundTripJson(MultipleLinksSameRelation);
+        }
+
+        private const string SimpleLinksAndAttributes = @"{
+        '_links': {
+            'self': { 'href': '/orders' },
+            'next': { 'href': '/orders?page=2' },
+            'ea:find': {
+                'href': '/orders{?id}'
+            },
+            'ea:admin': [{
+                'href': '/admins/2',
+                'title': 'Fred'
+            }, {
+                'href': '/admins/5',
+                'title': 'Kate'
+            }]
+        },
+        'currentlyProcessing': 14,
+        'shippedToday': 20,
+        }";
+
+        [Test]
+        public void SimpleLinksAndAttributes_RoundTrip()
+        {
+            TestRoundTripJson(SimpleLinksAndAttributes);
+        }
+
+        public void TestRoundTripJson(string json)
+        {
+            var expected = JObject.Parse(json).ToString();
+
+            serializer.DeserializeToBuilder(expected, builder);
+
+            var result = serializer.Serialize(builder.ToRepresentor());
+
+            Assert.AreEqual(expected, result);
+        }
+
+    }
+}

--- a/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
+++ b/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
@@ -75,7 +75,21 @@ namespace Crichton.Representors.Tests
             sut.AddTransition(rel, uri);
             var result = sut.ToRepresentor();
 
-            result.Transitions.Should().Contain(t => t.Rel == rel && t.Uri == uri);
+            result.Transitions.Should().ContainSingle(t => t.Rel == rel && t.Uri == uri);
+
+        }
+
+        [Test]
+        public void AddTransition_CorrectlyAddsSimpleTransitionWithTitle()
+        {
+            var rel = Fixture.Create<string>();
+            var uri = Fixture.Create<string>();
+            var title = Fixture.Create<string>();
+
+            sut.AddTransition(rel, uri, title);
+            var result = sut.ToRepresentor();
+
+            result.Transitions.Should().ContainSingle(t => t.Rel == rel && t.Uri == uri && t.Title == title);
 
         }
     


### PR DESCRIPTION
- Added some integration round trip tests that check deserializing then serializing HAL Json keeps all information
- Support for "title" in HAL links, like:

``` json
    {
        "_links": {
            "self": { "href": "/orders" },
            "next": { "href": "/orders?page=2" },
            "ea:admin": [{
                "href": "/admins/2",
                "title": "Fred"
            }, {
                "href": "/admins/5",
                "title": "Kate"
            }]
        }}
```

@fosdev @brutski @sheavalentine-mdsol @BPONTES Comments welcome as always.
