### PR TITLE
Embedded Resource support in Representor and HAL Serializer

### DIFF
--- a/src/Crichton.Representors/CrichtonRepresentor.cs
+++ b/src/Crichton.Representors/CrichtonRepresentor.cs
@@ -9,11 +9,14 @@ namespace Crichton.Representors
 
         public JObject Attributes { get; set; }
 
-        public IList<CrichtonTransition> Transitions { get; set; }
+        public IList<CrichtonTransition> Transitions { get; private set; }
+
+        public Dictionary<string, IList<CrichtonRepresentor>> EmbeddedResources { get; private set; }
 
         public CrichtonRepresentor()
         {
             Transitions = new List<CrichtonTransition>();
+            EmbeddedResources = new Dictionary<string, IList<CrichtonRepresentor>>();
         }
 
         public T ToObject<T>()

--- a/src/Crichton.Representors/CrichtonTransition.cs
+++ b/src/Crichton.Representors/CrichtonTransition.cs
@@ -8,6 +8,7 @@ namespace Crichton.Representors
         public string Uri { get; set; }
         public string TemplatedUri { get; set; }
         public string InterfaceMethod { get; set; }
+        public string Title { get; set; }
         public IList<CrichtonTransitionAttribute> Attributes { get; set; } 
     }
 }

--- a/src/Crichton.Representors/IRepresentorBuilder.cs
+++ b/src/Crichton.Representors/IRepresentorBuilder.cs
@@ -10,5 +10,6 @@ namespace Crichton.Representors
         void SetAttributesFromObject(object data);
         void AddTransition(string rel, string uri);
         void AddTransition(string rel, string uri, string title);
+        void AddEmbeddedResource(string key, CrichtonRepresentor resource);
     }
 }

--- a/src/Crichton.Representors/IRepresentorBuilder.cs
+++ b/src/Crichton.Representors/IRepresentorBuilder.cs
@@ -9,5 +9,6 @@ namespace Crichton.Representors
         void SetAttributes(JObject attributes);
         void SetAttributesFromObject(object data);
         void AddTransition(string rel, string uri);
+        void AddTransition(string rel, string uri, string title);
     }
 }

--- a/src/Crichton.Representors/RepresentorBuilder.cs
+++ b/src/Crichton.Representors/RepresentorBuilder.cs
@@ -42,7 +42,15 @@ namespace Crichton.Representors
 
         public void AddTransition(string rel, string uri, string title)
         {
-            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri, Title = title});
+            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri, Title = title });
+        }
+
+        public void AddEmbeddedResource(string key, CrichtonRepresentor resource)
+        {
+            if (!representor.EmbeddedResources.ContainsKey(key))
+                representor.EmbeddedResources[key] = new List<CrichtonRepresentor>();
+
+            representor.EmbeddedResources[key].Add(resource);
         }
     }
 }

--- a/src/Crichton.Representors/RepresentorBuilder.cs
+++ b/src/Crichton.Representors/RepresentorBuilder.cs
@@ -37,7 +37,12 @@ namespace Crichton.Representors
 
         public void AddTransition(string rel, string uri)
         {
-            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri});
+            AddTransition(rel, uri, null);
+        }
+
+        public void AddTransition(string rel, string uri, string title)
+        {
+            representor.Transitions.Add(new CrichtonTransition() { Rel = rel, Uri = uri, Title = title});
         }
     }
 }

--- a/src/Crichton.Representors/Serializers/HalSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HalSerializer.cs
@@ -112,7 +112,6 @@ namespace Crichton.Representors.Serializers
             // set builder attributes to be that of root properties in message
             builder.SetAttributes(document);
 
-
             return builder;
         }
 

--- a/src/Crichton.Representors/Serializers/ISerializer.cs
+++ b/src/Crichton.Representors/Serializers/ISerializer.cs
@@ -1,8 +1,10 @@
-﻿namespace Crichton.Representors.Serializers
+﻿using System;
+
+namespace Crichton.Representors.Serializers
 {
     public interface ISerializer
     {
         string Serialize(CrichtonRepresentor representor);
-        void DeserializeToBuilder(string message, IRepresentorBuilder builder);
+        IRepresentorBuilder DeserializeToNewBuilder(string message, Func<IRepresentorBuilder> builderFactoryMethod);
     }
 }

--- a/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
+++ b/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="CrichtonRepresentorTests.cs" />
     <Compile Include="ExampleDataObject.cs" />
+    <Compile Include="Integration\HalSerializerRoundTrips.cs" />
     <Compile Include="RepresentorBuilderTests.cs" />
     <Compile Include="Serializers\HalSerializerTests.cs" />
     <Compile Include="TestWithFixture.cs" />

--- a/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
+++ b/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
@@ -14,13 +14,11 @@ namespace Crichton.Representors.Tests.Integration
     public class HalSerializerRoundTrips : TestWithFixture
     {
         private HalSerializer serializer;
-        private RepresentorBuilder builder;
 
         [SetUp]
         public void Init()
         {
             serializer = new HalSerializer();
-            builder = new RepresentorBuilder();
             Fixture = GetFixture();
         }
 
@@ -82,7 +80,7 @@ namespace Crichton.Representors.Tests.Integration
         {
             var expected = JObject.Parse(json).ToString();
 
-            serializer.DeserializeToBuilder(expected, builder);
+            var builder = serializer.DeserializeToNewBuilder(expected, () => new RepresentorBuilder());
 
             var result = serializer.Serialize(builder.ToRepresentor());
 

--- a/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
+++ b/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
@@ -22,7 +22,6 @@ namespace Crichton.Representors.Tests.Integration
             Fixture = GetFixture();
         }
 
-
         public void TestRoundTripJson(string json)
         {
             var expected = JObject.Parse(json).ToString();
@@ -31,7 +30,7 @@ namespace Crichton.Representors.Tests.Integration
 
             var result = serializer.Serialize(builder.ToRepresentor());
 
-            Assert.AreEqual(expected, result);
+            Assert.AreEqual(expected, JObject.Parse(result).ToString());
         }
 
         private const string SelfLinkOnly = @"{

--- a/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
+++ b/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
@@ -22,6 +22,18 @@ namespace Crichton.Representors.Tests.Integration
             Fixture = GetFixture();
         }
 
+
+        public void TestRoundTripJson(string json)
+        {
+            var expected = JObject.Parse(json).ToString();
+
+            var builder = serializer.DeserializeToNewBuilder(expected, () => new RepresentorBuilder());
+
+            var result = serializer.Serialize(builder.ToRepresentor());
+
+            Assert.AreEqual(expected, result);
+        }
+
         private const string SelfLinkOnly = @"{
             '_links': {
                 'self': { 'href': '/example_resource' }
@@ -76,15 +88,55 @@ namespace Crichton.Representors.Tests.Integration
             TestRoundTripJson(SimpleLinksAndAttributes);
         }
 
-        public void TestRoundTripJson(string json)
+
+        // From "Resources" here: https://phlyrestfully.readthedocs.org/en/latest/halprimer.html
+        private const string ComplexEmbeddedResources = @"
         {
-            var expected = JObject.Parse(json).ToString();
+            '_links': {
+                'self': {
+                    'href': 'http://example.org/api/user/matthew'
+                }
+            },
+            'id': 'matthew',
+            'name': 'Matthew Weier O\'Phinney',
+            '_embedded': {
+                'contacts': [
+                    {
+                        '_links': {
+                            'self': {
+                                'href': 'http://example.org/api/user/mac_nibblet'
+                            }
+                        },
+                        'id': 'mac_nibblet',
+                        'name': 'Antoine Hedgecock'
+                    },
+                    {
+                        '_links': {
+                            'self': {
+                                'href': 'http://example.org/api/user/spiffyjr'
+                            }
+                        },
+                        'id': 'spiffyjr',
+                        'name': 'Kyle Spraggs'
+                    }
+                ],
+                'website': {
+                    '_links': {
+                        'self': {
+                            'href': 'http://example.org/api/locations/mwop'
+                        }
+                    },
+                    'id': 'mwop',
+                    'url': 'http://www.mwop.net'
+                },
+            }
+        }
+        ";
 
-            var builder = serializer.DeserializeToNewBuilder(expected, () => new RepresentorBuilder());
-
-            var result = serializer.Serialize(builder.ToRepresentor());
-
-            Assert.AreEqual(expected, result);
+        [Test]
+        public void ComplexEmbeddedResources_RoundTrip()
+        {
+            TestRoundTripJson(ComplexEmbeddedResources);
         }
 
     }

--- a/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
+++ b/tests/Crichton.Representors.Tests/Integration/HalSerializerRoundTrips.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Crichton.Representors.Serializers;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using Rhino.Mocks;
+
+namespace Crichton.Representors.Tests.Integration
+{
+    public class HalSerializerRoundTrips : TestWithFixture
+    {
+        private HalSerializer serializer;
+        private RepresentorBuilder builder;
+
+        [SetUp]
+        public void Init()
+        {
+            serializer = new HalSerializer();
+            builder = new RepresentorBuilder();
+            Fixture = GetFixture();
+        }
+
+        private const string SelfLinkOnly = @"{
+            '_links': {
+                'self': { 'href': '/example_resource' }
+            }
+        }";
+
+        [Test]
+        public void SelfLinkOnly_RoundTrip()
+        {
+            TestRoundTripJson(SelfLinkOnly);
+        }
+
+        private const string MultipleLinksSameRelation = @"
+        {
+            '_links': {
+              'items': [{
+                  'href': '/first_item'
+              },{
+                  'href': '/second_item'
+              }]
+            }
+        }";
+
+        [Test]
+        public void MultipleLinksSameRelation_RoundTrip()
+        {
+            TestRoundTripJson(MultipleLinksSameRelation);
+        }
+
+        private const string SimpleLinksAndAttributes = @"{
+        '_links': {
+            'self': { 'href': '/orders' },
+            'next': { 'href': '/orders?page=2' },
+            'ea:find': {
+                'href': '/orders{?id}'
+            },
+            'ea:admin': [{
+                'href': '/admins/2',
+                'title': 'Fred'
+            }, {
+                'href': '/admins/5',
+                'title': 'Kate'
+            }]
+        },
+        'currentlyProcessing': 14,
+        'shippedToday': 20,
+        }";
+
+        [Test]
+        public void SimpleLinksAndAttributes_RoundTrip()
+        {
+            TestRoundTripJson(SimpleLinksAndAttributes);
+        }
+
+        public void TestRoundTripJson(string json)
+        {
+            var expected = JObject.Parse(json).ToString();
+
+            serializer.DeserializeToBuilder(expected, builder);
+
+            var result = serializer.Serialize(builder.ToRepresentor());
+
+            Assert.AreEqual(expected, result);
+        }
+
+    }
+}

--- a/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
+++ b/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
@@ -92,6 +92,18 @@ namespace Crichton.Representors.Tests
             result.Transitions.Should().ContainSingle(t => t.Rel == rel && t.Uri == uri && t.Title == title);
 
         }
+
+        [Test]
+        public void AddEmbeddedResource_AddsResourceWithCorrectKey()
+        {
+            var key = Fixture.Create<string>();
+            var resource = Fixture.Create<CrichtonRepresentor>();
+
+            sut.AddEmbeddedResource(key, resource);
+            var result = sut.ToRepresentor();
+
+            result.EmbeddedResources[key].Should().ContainSingle(t => t == resource);
+        }
     
     }
 }

--- a/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
+++ b/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
@@ -75,7 +75,21 @@ namespace Crichton.Representors.Tests
             sut.AddTransition(rel, uri);
             var result = sut.ToRepresentor();
 
-            result.Transitions.Should().Contain(t => t.Rel == rel && t.Uri == uri);
+            result.Transitions.Should().ContainSingle(t => t.Rel == rel && t.Uri == uri);
+
+        }
+
+        [Test]
+        public void AddTransition_CorrectlyAddsSimpleTransitionWithTitle()
+        {
+            var rel = Fixture.Create<string>();
+            var uri = Fixture.Create<string>();
+            var title = Fixture.Create<string>();
+
+            sut.AddTransition(rel, uri, title);
+            var result = sut.ToRepresentor();
+
+            result.Transitions.Should().ContainSingle(t => t.Rel == rel && t.Uri == uri && t.Title == title);
 
         }
     

--- a/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
+++ b/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
@@ -104,6 +104,5 @@ namespace Crichton.Representors.Tests
 
             result.EmbeddedResources[key].Should().ContainSingle(t => t == resource);
         }
-    
     }
 }


### PR DESCRIPTION
Includes everything in https://github.com/mdsol/crichton-dotnet/pull/7 plus Embedded Resource support. Each keyed embedded resource consists of one or more Representors. Tests for the HAL Serializer included.

@fosdev @BPONTES @sheavalentine-mdsol @brutski @cabbott @chad-medi @jcarres-mdsol Enjoy
