### PR TITLE
Hale Link Object Data support Part 1

### DIFF
--- a/src/Crichton.Representors/Crichton.Representors.csproj
+++ b/src/Crichton.Representors/Crichton.Representors.csproj
@@ -38,9 +38,11 @@
     <Compile Include="CrichtonRepresentor.cs" />
     <Compile Include="CrichtonTransition.cs" />
     <Compile Include="CrichtonTransitionAttribute.cs" />
+    <Compile Include="IAttributesContainer.cs" />
     <Compile Include="IRepresentorBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepresentorBuilder.cs" />
+    <Compile Include="Serializers\DictionaryExtensions.cs" />
     <Compile Include="Serializers\HaleSerializer.cs" />
     <Compile Include="Serializers\HalSerializer.cs" />
     <Compile Include="Serializers\ISerializer.cs" />

--- a/src/Crichton.Representors/CrichtonTransition.cs
+++ b/src/Crichton.Representors/CrichtonTransition.cs
@@ -9,7 +9,7 @@ namespace Crichton.Representors
         Resource = 2
     }
 
-    public class CrichtonTransition
+    public class CrichtonTransition : IAttributesContainer
     {
         public string Rel { get; set; }
         public string Uri { get; set; }

--- a/src/Crichton.Representors/CrichtonTransition.cs
+++ b/src/Crichton.Representors/CrichtonTransition.cs
@@ -25,6 +25,11 @@ namespace Crichton.Representors
         public string[] MediaTypesAccepted { get; set; }
         public TransitionRenderMethod RenderMethod { get; set; }
         public string Target { get; set; }
-        public IList<CrichtonTransitionAttribute> Attributes { get; set; } 
+        public IDictionary<string, CrichtonTransitionAttribute> Attributes { get; set; }
+
+        public CrichtonTransition()
+        {
+            Attributes = new Dictionary<string, CrichtonTransitionAttribute>();
+        }
     }
 }

--- a/src/Crichton.Representors/CrichtonTransition.cs
+++ b/src/Crichton.Representors/CrichtonTransition.cs
@@ -26,10 +26,12 @@ namespace Crichton.Representors
         public TransitionRenderMethod RenderMethod { get; set; }
         public string Target { get; set; }
         public IDictionary<string, CrichtonTransitionAttribute> Attributes { get; set; }
+        public IDictionary<string, CrichtonTransitionAttribute> Parameters { get; set; }
 
         public CrichtonTransition()
         {
             Attributes = new Dictionary<string, CrichtonTransitionAttribute>();
+            Parameters = new Dictionary<string, CrichtonTransitionAttribute>();
         }
     }
 }

--- a/src/Crichton.Representors/CrichtonTransitionAttribute.cs
+++ b/src/Crichton.Representors/CrichtonTransitionAttribute.cs
@@ -9,6 +9,7 @@ namespace Crichton.Representors
         public string JsonType { get; set; }
         public string DataType { get; set; }
         public string Constraints { get; set; }
-        public IList<string> Options { get; set; } 
+        public IList<string> Options { get; set; }
+        public IDictionary<string, CrichtonTransitionAttribute> Attributes { get; set; }
     }
 }

--- a/src/Crichton.Representors/CrichtonTransitionAttribute.cs
+++ b/src/Crichton.Representors/CrichtonTransitionAttribute.cs
@@ -6,7 +6,7 @@ namespace Crichton.Representors
     public class CrichtonTransitionAttribute
     {
         public string Default { get; set; }
-        public string Description { get; set; }
+        public string ProfileUri { get; set; }
         public string JsonType { get; set; }
         public string DataType { get; set; }
         public string Constraints { get; set; }

--- a/src/Crichton.Representors/CrichtonTransitionAttribute.cs
+++ b/src/Crichton.Representors/CrichtonTransitionAttribute.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Crichton.Representors
 {
     public class CrichtonTransitionAttribute
     {
-        public string Default { get; set; }
+        public object Value { get; set; }
         public string ProfileUri { get; set; }
         public string JsonType { get; set; }
         public string DataType { get; set; }

--- a/src/Crichton.Representors/CrichtonTransitionAttribute.cs
+++ b/src/Crichton.Representors/CrichtonTransitionAttribute.cs
@@ -8,8 +8,14 @@ namespace Crichton.Representors
         public string ProfileUri { get; set; }
         public string JsonType { get; set; }
         public string DataType { get; set; }
-        public string Constraints { get; set; }
         public IList<string> Options { get; set; }
         public IDictionary<string, CrichtonTransitionAttribute> Attributes { get; set; }
+        public IDictionary<string, CrichtonTransitionAttribute> Parameters { get; set; }
+
+        public CrichtonTransitionAttribute()
+        {
+            Attributes = new Dictionary<string, CrichtonTransitionAttribute>();
+            Parameters = new Dictionary<string, CrichtonTransitionAttribute>();
+        }
     }
 }

--- a/src/Crichton.Representors/CrichtonTransitionAttribute.cs
+++ b/src/Crichton.Representors/CrichtonTransitionAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Crichton.Representors
 {
-    public class CrichtonTransitionAttribute
+    public class CrichtonTransitionAttribute : IAttributesContainer
     {
         public object Value { get; set; }
         public string ProfileUri { get; set; }

--- a/src/Crichton.Representors/CrichtonTransitionAttribute.cs
+++ b/src/Crichton.Representors/CrichtonTransitionAttribute.cs
@@ -5,11 +5,10 @@ namespace Crichton.Representors
 {
     public class CrichtonTransitionAttribute
     {
-        public string Name { get; set; }
         public string Default { get; set; }
         public string Description { get; set; }
-        public string Type { get; set; }
-        public Type DataType { get; set; }
+        public string JsonType { get; set; }
+        public string DataType { get; set; }
         public string Constraints { get; set; }
         public IList<string> Options { get; set; } 
     }

--- a/src/Crichton.Representors/IAttributesContainer.cs
+++ b/src/Crichton.Representors/IAttributesContainer.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Crichton.Representors
+{
+    public interface IAttributesContainer
+    {
+        IDictionary<string, CrichtonTransitionAttribute> Attributes { get; set; }
+        IDictionary<string, CrichtonTransitionAttribute> Parameters { get; set; }
+    }
+}

--- a/src/Crichton.Representors/Serializers/DictionaryExtensions.cs
+++ b/src/Crichton.Representors/Serializers/DictionaryExtensions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Crichton.Representors.Serializers
+{
+    // adapted from http://stackoverflow.com/a/2679857
+    public static class DictionaryExtensions
+    {
+        public static T MergeLeft<T, TK, TV>(this T left, params IDictionary<TK, TV>[] right)
+            where T : IDictionary<TK, TV>, new()
+        {
+            var newMap = new T();
+            foreach (var p in (new List<IDictionary<TK, TV>> { left }).Concat(right).SelectMany(src => src))
+            {
+                newMap[p.Key] = p.Value;
+            }
+            return newMap;
+        }
+
+    }
+}

--- a/src/Crichton.Representors/Serializers/HaleSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HaleSerializer.cs
@@ -53,6 +53,7 @@ namespace Crichton.Representors.Serializers
                 foreach (var attribute in transition.Attributes)
                 {
                     var attributeObject = new JObject();
+
                     if (!String.IsNullOrWhiteSpace(attribute.Value.JsonType))
                     {
                         var typeValue = new StringBuilder(attribute.Value.JsonType);
@@ -62,7 +63,11 @@ namespace Crichton.Representors.Serializers
                             typeValue.Append(attribute.Value.DataType);
                         }
                         attributeObject["type"] = typeValue.ToString();
+                    }
 
+                    if (!String.IsNullOrWhiteSpace(attribute.Value.ProfileUri))
+                    {
+                        attributeObject["profile"] = attribute.Value.ProfileUri;
                     }
 
                     dataObject[attribute.Key] = attributeObject;
@@ -111,6 +116,7 @@ namespace Crichton.Representors.Serializers
                 {
                     var dataObject = data[dataProperty.Name];
                     var type = dataObject["type"];
+                    var profileUri = dataObject["profile"];
 
                     var transitionAttribute = new CrichtonTransitionAttribute();
 
@@ -120,6 +126,8 @@ namespace Crichton.Representors.Serializers
                         transitionAttribute.JsonType = splitType[0];
                         if (splitType.Count() > 1) transitionAttribute.DataType = splitType[1];
                     }
+
+                    if (profileUri != null) transitionAttribute.ProfileUri = profileUri.Value<string>();
 
                     transition.Attributes[dataProperty.Name] = transitionAttribute;
                 }

--- a/src/Crichton.Representors/Serializers/HaleSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HaleSerializer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors.Serializers
@@ -172,9 +171,11 @@ namespace Crichton.Representors.Serializers
                 var dataObject = data[dataProperty.Name];
                 var type = dataObject["type"];
                 var profileUri = dataObject["profile"];
-                var value = dataObject["value"];
+                var value = dataObject["value"] as JValue;
                 var dataToken = dataObject["data"];
                 var scope = dataObject["scope"];
+
+                if (scope == null && matchingScope != null) continue;
 
                 if (scope != null)
                 {
@@ -192,7 +193,10 @@ namespace Crichton.Representors.Serializers
 
                 if (profileUri != null) transitionAttribute.ProfileUri = profileUri.Value<string>();
 
-                if (value != null) transitionAttribute.Value = JsonConvert.DeserializeObject(value.ToString());
+                if (value != null)
+                {
+                    transitionAttribute.Value = value.Value;
+                }
 
                 SetAttributesAndParametersOnAttributesContainer(dataToken, transitionAttribute);
 

--- a/src/Crichton.Representors/Serializers/HaleSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HaleSerializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors.Serializers
@@ -70,6 +71,11 @@ namespace Crichton.Representors.Serializers
                         attributeObject["profile"] = attribute.Value.ProfileUri;
                     }
 
+                    if (attribute.Value.Value != null)
+                    {
+                        attributeObject["value"] = JToken.FromObject(attribute.Value.Value);
+                    }
+
                     dataObject[attribute.Key] = attributeObject;
                 }
             }
@@ -117,6 +123,7 @@ namespace Crichton.Representors.Serializers
                     var dataObject = data[dataProperty.Name];
                     var type = dataObject["type"];
                     var profileUri = dataObject["profile"];
+                    var value = dataObject["value"];
 
                     var transitionAttribute = new CrichtonTransitionAttribute();
 
@@ -128,6 +135,8 @@ namespace Crichton.Representors.Serializers
                     }
 
                     if (profileUri != null) transitionAttribute.ProfileUri = profileUri.Value<string>();
+
+                    if (value != null) transitionAttribute.Value = JsonConvert.DeserializeObject(value.ToString());
 
                     transition.Attributes[dataProperty.Name] = transitionAttribute;
                 }

--- a/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
+++ b/tests/Crichton.Representors.Tests/Crichton.Representors.Tests.csproj
@@ -94,6 +94,9 @@
     <Content Include="Integration\TestData\Hal\SimpleLinksAndAttributes.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Integration\TestData\Hale\LinkObjectDataAttributes.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Integration\TestData\Hale\AllLinkObjectPropertiesExceptData.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/Crichton.Representors.Tests/Integration/HaleSerializerRoundTrips.cs
+++ b/tests/Crichton.Representors.Tests/Integration/HaleSerializerRoundTrips.cs
@@ -24,6 +24,12 @@ namespace Crichton.Representors.Tests.Integration
         {
             TestRoundTripFromJsonTestData("Hale\\AllLinkObjectPropertiesExceptData", serializer);
         }
+
+        [Test]
+        public void LinkObjectDataAttributes_RoundTrip()
+        {
+            TestRoundTripFromJsonTestData("Hale\\LinkObjectDataAttributes", serializer);
+        }
     
     }
 }

--- a/tests/Crichton.Representors.Tests/Integration/TestData/Hale/LinkObjectDataAttributes.json
+++ b/tests/Crichton.Representors.Tests/Integration/TestData/Hale/LinkObjectDataAttributes.json
@@ -1,0 +1,42 @@
+﻿{
+   "_links":{
+      "self":{
+         "href":"http://example.org/api/user/ed"
+      },
+      "testrel":{
+         "href":"http://example.org/api/user/test",
+         "data" : {
+             "searchname" : {
+                 "scope" : "href",
+                 "type" : "string:text"
+             }
+         }
+      }
+   },
+   "some-property":123,
+   "_embedded":{
+      "embedded1":{
+         "_links":{
+            "self":{
+               "href":"http://nice.com"
+            },
+            "testrel":{
+               "href":"http://example.org/api/user/test",
+               "data" : {
+                   "name" : {
+                       "value" : 1234,
+                       "data" : {
+                           "lastname" :
+                               {
+                               "value" : "Albers",
+                               "profile" : "http://nice-profile-hypermedia.com/hypermedia"
+                           }
+                       }
+                    }
+               }
+            }
+         },
+         "some-property":1234
+      }
+   }
+}

--- a/tests/Crichton.Representors.Tests/TestWithFixture.cs
+++ b/tests/Crichton.Representors.Tests/TestWithFixture.cs
@@ -1,4 +1,5 @@
-﻿using Ploeh.AutoFixture;
+﻿using System.Linq;
+using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoRhinoMock;
 
 namespace Crichton.Representors.Tests
@@ -9,7 +10,10 @@ namespace Crichton.Representors.Tests
 
         public IFixture GetFixture()
         {
-            return new Fixture().Customize(new MultipleCustomization()).Customize(new AutoRhinoMockCustomization());
+            var fixture = new Fixture().Customize(new MultipleCustomization()).Customize(new AutoRhinoMockCustomization());
+            fixture.Behaviors.Remove(fixture.Behaviors.OfType<ThrowingRecursionBehavior>().Single());
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+            return fixture;
         }
     }
 }


### PR DESCRIPTION
Supports Hale Link Object Data, but still missing constraints.

```
5.1. Data Properties
5.1.1. type
The "type" property is OPTIONAL.
Specifies the expected type of the data. Servers MAY provide type information in the format: primitive_type{:data_type}, where the primitive_type is a down-cased JSON primitive and the data_type is OPTIONAL. Clients should at least recognize data_type values associated with data-related
HTML 5 "input" element control types.
Default value is "string" if unspecified.
5.1.2. data
The "data" property is OPTIONAL.
Specifying a "data" property supports recursively defining data properties of objects as data values.
5.1.3. scope
The "scope" property is OPTIONAL.
--- href means the data object applies to the query string templated in href.
--- either means POST and the query string.
Specifies the scope of the Data Object. Servers MAY specify "href" or "either".
If a Link Object is templated and no Data Object with a property for the template variable name exists, a client should assume there are no constraints associated with the URI template variable.
Specifying "href" indicates the object only applies to URI template variables. 
Specifying the value "either" indicates the object applies to either a URI template variable of the same name and that a body property SHOULD be supplied according to the properties of the object.
If unspecified, the Data Object specifies information about property values to be submitted as part of the request body.
5.1.4. profile
The "profile" property is OPTIONAL.
Its value is a string which is a URI that hints about the profile (as defined by I-D.wilde-profile-link) of the related resource.
5.1.5. value
The "value" property is OPTIONAL.
Specifies the current or default value.
```

@mdsol/hypermedia-team Please review and merge.
