### PR TITLE
[MCC-105863] Include version number in .nuspec to work around a NuGet bug

### DIFF
--- a/src/Crichton.Representors/Crichton.Representors.nuspec
+++ b/src/Crichton.Representors/Crichton.Representors.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Crichton.Representors</id>
     <title>Crichton Hypermedia Representors</title>
-    <version>$version$</version>
+    <version>0.1.4-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
     <authors>Ed Andersen</authors>
     <copyright>Medidata Solutions</copyright>
     <licenseUrl>https://github.com/mdsol/crichton-dotnet/blob/develop/LICENSE.md</licenseUrl>


### PR DESCRIPTION
NuGet 2.8 has a bug with Portable Class Libraries: https://nuget.codeplex.com/workitem/4013. Until this is fixed, we have to keep the version number also in the .nuspec files. This sucks but hey ho.

@kenyamat Please merge.
