### PR TITLE
[MCC-114942] Fixed a possible NullReferenceException

### DIFF
--- a/src/Crichton.Representors/Crichton.Representors.nuspec
+++ b/src/Crichton.Representors/Crichton.Representors.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Crichton.Representors</id>
     <title>Crichton Hypermedia Representors</title>
-    <version>0.1.4-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
+    <version>0.1.5-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
     <authors>Ed Andersen</authors>
     <copyright>Medidata Solutions</copyright>
     <licenseUrl>https://github.com/mdsol/crichton-dotnet/blob/develop/LICENSE.md</licenseUrl>

--- a/src/Crichton.Representors/Properties/AssemblyInfo.cs
+++ b/src/Crichton.Representors/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.4")]
-[assembly: AssemblyFileVersionAttribute("0.1.4")]
-[assembly: AssemblyInformationalVersion("0.1.4-alpha")]
+[assembly: AssemblyVersion("0.1.5")]
+[assembly: AssemblyFileVersionAttribute("0.1.5")]
+[assembly: AssemblyInformationalVersion("0.1.5-alpha")]

--- a/src/Crichton.Representors/Serializers/HalSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HalSerializer.cs
@@ -7,8 +7,8 @@ namespace Crichton.Representors.Serializers
 {
     public class HalSerializer : ISerializer
     {
-        private static readonly string[] ReservedAttributes = {"_links", "_embedded"};
-        private static readonly string[] ReservedLinkRels = {"self"};
+        private static readonly string[] ReservedAttributes = { "_links", "_embedded" };
+        private static readonly string[] ReservedLinkRels = { "self" };
 
         public virtual string ContentType { get { return "application/hal+json"; } }
 
@@ -31,9 +31,12 @@ namespace Crichton.Representors.Serializers
             }
 
             // add a root property for each property on data
-            foreach (var property in representor.Attributes.Properties().Where(p => !ReservedAttributes.Contains(p.Name)))
+            if (representor.Attributes != null)
             {
-                jObject.Add(property.Name, property.Value);
+                foreach (var property in representor.Attributes.Properties().Where(p => !ReservedAttributes.Contains(p.Name)))
+                {
+                    jObject.Add(property.Name, property.Value);
+                }
             }
 
             // embedded resources and Collections both require _embedded
@@ -82,13 +85,13 @@ namespace Crichton.Representors.Serializers
             var existingRel = document["_links"][transition.Rel];
             if (existingRel == null)
             {
-                var jobject = (JObject) document["_links"];
+                var jobject = (JObject)document["_links"];
                 jobject.Add(transition.Rel, CreateLinkObjectFromTransition(transition));
             }
             else
             {
                 // we already have a ref. Need to convert this to an array if not already.
-                var array = existingRel as JArray ?? new JArray {existingRel};
+                var array = existingRel as JArray ?? new JArray { existingRel };
                 array.Add(CreateLinkObjectFromTransition(transition));
 
                 // override the existing _links > rel
@@ -98,7 +101,7 @@ namespace Crichton.Representors.Serializers
 
         public virtual JObject CreateLinkObjectFromTransition(CrichtonTransition transition)
         {
-            var linkObject = new JObject {{"href", transition.Uri}};
+            var linkObject = new JObject { { "href", transition.Uri } };
             if (!String.IsNullOrWhiteSpace(transition.Title)) linkObject["title"] = transition.Title;
             if (!String.IsNullOrWhiteSpace(transition.Type)) linkObject["type"] = transition.Type;
             if (transition.UriIsTemplated) linkObject["templated"] = true;
@@ -113,7 +116,7 @@ namespace Crichton.Representors.Serializers
         public IRepresentorBuilder DeserializeToNewBuilder(string message, Func<IRepresentorBuilder> builderFactoryMethod)
         {
             var document = JObject.Parse(message);
-            
+
             var builder = BuildRepresentorBuilderFromJObject(builderFactoryMethod, document);
 
             return builder;
@@ -194,7 +197,7 @@ namespace Crichton.Representors.Serializers
         {
             if (document["_links"] == null) return;
 
-            foreach (var child in ((JObject) document["_links"]).Properties())
+            foreach (var child in ((JObject)document["_links"]).Properties())
             {
                 var rel = child.Name;
 
@@ -209,7 +212,7 @@ namespace Crichton.Representors.Serializers
                     // create a transition for each array element
                     foreach (var link in array)
                     {
-                         builder.AddTransition(GetTransitionFromLinkObject(link, rel));
+                        builder.AddTransition(GetTransitionFromLinkObject(link, rel));
                     }
                 }
             }
@@ -225,7 +228,7 @@ namespace Crichton.Representors.Serializers
             var name = link["name"];
             var profile = link["profile"];
             var hreflang = link["hreflang"];
-            var templated = templatedField != null && (bool) templatedField;
+            var templated = templatedField != null && (bool)templatedField;
 
             var transition = new CrichtonTransition
             {

--- a/tests/Crichton.Representors.Tests/Serializers/HalSerializerTests.cs
+++ b/tests/Crichton.Representors.Tests/Serializers/HalSerializerTests.cs
@@ -30,6 +30,14 @@ namespace Crichton.Representors.Tests.Serializers
         }
 
         [Test]
+        public void Serialize_WorksWithEmptyRepresentor()
+        {
+            var representor = new CrichtonRepresentor();
+
+            sut.Serialize(representor);
+        }
+
+        [Test]
         public void Serialize_SelfLinkIsSet()
         {
             var representor = Fixture.Create<CrichtonRepresentor>();


### PR DESCRIPTION
I had fixed this during my spike but @kenyamat found it again. Now you can do:

``` csharp
            var representor = new CrichtonRepresentor();

            halSerializer.Serialize(representor);
```

Without it blowing up. Also bumped version to 0.1.5-alpha.

@kenyamat please review and merge.
