### PR TITLE
[MCC-114478] Added guard clauses in all public methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Copyright (c) 2014 Medidata Solutions Worldwide. Licensed under MIT. See [LICENS
 ## Authors
 
 * [Ed Andersen](https://github.com/edandersen) - [@edandersen](https://twitter.com/edandersen)
+* [Kenya Matsumoto](https://github.com/kenyamat)
 * Based on the work by [Mark W. Foster](https://github.com/fosdev)
 
 [CONTRIBUTING]: CONTRIBUTING.md

--- a/src/Crichton.Representors/CrichtonRepresentor.cs
+++ b/src/Crichton.Representors/CrichtonRepresentor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors
@@ -29,6 +30,11 @@ namespace Crichton.Representors
 
         public void SetAttributesFromObject(object data)
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
+
             Attributes = JObject.FromObject(data);
         }
     }

--- a/src/Crichton.Representors/Properties/AssemblyInfo.cs
+++ b/src/Crichton.Representors/Properties/AssemblyInfo.cs
@@ -29,6 +29,6 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.5")]
-[assembly: AssemblyFileVersionAttribute("0.1.5")]
-[assembly: AssemblyInformationalVersion("0.1.5-alpha")]
+[assembly: AssemblyVersion("0.1.6")]
+[assembly: AssemblyFileVersionAttribute("0.1.6")]
+[assembly: AssemblyInformationalVersion("0.1.6-alpha")]

--- a/src/Crichton.Representors/RepresentorBuilder.cs
+++ b/src/Crichton.Representors/RepresentorBuilder.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Newtonsoft.Json.Linq;
 
 namespace Crichton.Representors
@@ -22,33 +20,68 @@ namespace Crichton.Representors
 
         public void SetSelfLink(string self)
         {
+            if (string.IsNullOrWhiteSpace(self))
+            {
+                throw new ArgumentNullException("self");
+            }
+
             representor.SelfLink = self;
         }
 
         public void SetAttributes(JObject attributes)
         {
+            if (attributes == null)
+            {
+                throw new ArgumentNullException("attributes");
+            }
+
             representor.Attributes = attributes;
         }
 
         public void SetAttributesFromObject(object data)
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException("data");
+            }
+
             representor.Attributes = JObject.FromObject(data);
         }
 
         public void AddTransition(CrichtonTransition transition)
         {
+            if (transition == null)
+            {
+                throw new ArgumentNullException("transition");
+            }
+
             representor.Transitions.Add(transition);
         }
 
         public void AddTransition(string rel, string uri = null, string title = null, string type = null, bool uriIsTemplated = false, 
             string depreciationUri = null, string name = null, string profileUri = null, string languageTag = null)
         {
+            if (string.IsNullOrWhiteSpace(rel))
+            {
+                throw new ArgumentNullException("rel");
+            }
+
             representor.Transitions.Add(new CrichtonTransition { Rel = rel, Uri = uri, Title = title, Type = type, 
                 UriIsTemplated = uriIsTemplated, DepreciationUri = depreciationUri, Name = name, ProfileUri = profileUri, LanguageTag = languageTag});
         }
 
         public void AddEmbeddedResource(string key, CrichtonRepresentor resource)
         {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if (resource == null)
+            {
+                throw new ArgumentNullException("resource");
+            }
+
             if (!representor.EmbeddedResources.ContainsKey(key))
                 representor.EmbeddedResources[key] = new List<CrichtonRepresentor>();
 
@@ -57,12 +90,27 @@ namespace Crichton.Representors
 
         public void SetCollection(IEnumerable<CrichtonRepresentor> representors)
         {
+            if (representors == null)
+            {
+                throw new ArgumentNullException("representors");
+            }
+
             foreach(var representorInCollection in representors)
                 representor.Collection.Add(representorInCollection);
         }
 
         public void SetCollection<T>(IEnumerable<T> collection, Func<T, string> selfLinkFunc)
         {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+
+            if (selfLinkFunc == null)
+            {
+                throw new ArgumentNullException("selfLinkFunc");
+            }
+
             foreach (var item in collection)
             {
                 var newRepresentor = new CrichtonRepresentor {SelfLink = selfLinkFunc(item)};

--- a/src/Crichton.Representors/Serializers/HalSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HalSerializer.cs
@@ -14,6 +14,11 @@ namespace Crichton.Representors.Serializers
 
         public string Serialize(CrichtonRepresentor representor)
         {
+            if (representor == null)
+            {
+                throw new ArgumentNullException("representor");
+            }
+
             var jObject = CreateJObjectForRepresentor(representor);
 
             return jObject.ToString();
@@ -99,7 +104,7 @@ namespace Crichton.Representors.Serializers
             }
         }
 
-        public virtual JObject CreateLinkObjectFromTransition(CrichtonTransition transition)
+        protected virtual JObject CreateLinkObjectFromTransition(CrichtonTransition transition)
         {
             var linkObject = new JObject { { "href", transition.Uri } };
             if (!String.IsNullOrWhiteSpace(transition.Title)) linkObject["title"] = transition.Title;
@@ -115,6 +120,16 @@ namespace Crichton.Representors.Serializers
 
         public IRepresentorBuilder DeserializeToNewBuilder(string message, Func<IRepresentorBuilder> builderFactoryMethod)
         {
+            if (message == null)
+            {
+                throw new ArgumentNullException("message");
+            }
+
+            if (builderFactoryMethod == null)
+            {
+                throw new ArgumentNullException("builderFactoryMethod");
+            }
+
             var document = JObject.Parse(message);
 
             var builder = BuildRepresentorBuilderFromJObject(builderFactoryMethod, document);
@@ -218,7 +233,7 @@ namespace Crichton.Representors.Serializers
             }
         }
 
-        public virtual CrichtonTransition GetTransitionFromLinkObject(JToken link, string rel)
+        protected virtual CrichtonTransition GetTransitionFromLinkObject(JToken link, string rel)
         {
             var href = link["href"];
             var title = link["title"];

--- a/src/Crichton.Representors/Serializers/HaleSerializer.cs
+++ b/src/Crichton.Representors/Serializers/HaleSerializer.cs
@@ -13,7 +13,7 @@ namespace Crichton.Representors.Serializers
 
         public override string ContentType { get { return "application/vnd.hale+json"; } }
 
-        public override JObject CreateLinkObjectFromTransition(CrichtonTransition transition)
+        protected override JObject CreateLinkObjectFromTransition(CrichtonTransition transition)
         {
             var linkObject = base.CreateLinkObjectFromTransition(transition);
 
@@ -116,7 +116,7 @@ namespace Crichton.Representors.Serializers
             }
         }
 
-        public override CrichtonTransition GetTransitionFromLinkObject(JToken link, string rel)
+        protected override CrichtonTransition GetTransitionFromLinkObject(JToken link, string rel)
         {
             var transition = base.GetTransitionFromLinkObject(link, rel);
 

--- a/tests/Crichton.Representors.Tests/CrichtonRepresentorTests.cs
+++ b/tests/Crichton.Representors.Tests/CrichtonRepresentorTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
@@ -40,6 +41,13 @@ namespace Crichton.Representors.Tests
                 Assert.AreEqual(expectedJObject[property.Name], sut.Attributes[property.Name]);
             }
 
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetAttributesFromObject_SetsAttributesWithNull()
+        {
+            sut.SetAttributesFromObject(null);
         }
 
         [Test]

--- a/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
+++ b/tests/Crichton.Representors.Tests/RepresentorBuilderTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -42,6 +39,13 @@ namespace Crichton.Representors.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetSelfLink_SetsSelfLinkWithNull()
+        {
+            sut.SetSelfLink(null);
+        }
+
+        [Test]
         public void SetAttributes_SetsRepresentorAttributes()
         {
             var attributes = new JObject();
@@ -49,6 +53,13 @@ namespace Crichton.Representors.Tests
             var result = sut.ToRepresentor();
 
             Assert.AreEqual(attributes, result.Attributes);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetAttributes_SetsRepresentorAttributesWithNull()
+        {
+            sut.SetAttributes(null);
         }
 
         [Test]
@@ -68,6 +79,13 @@ namespace Crichton.Representors.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetAttributesFromObject_SetsDataWithNull()
+        {
+            sut.SetAttributesFromObject(null);
+        }
+
+        [Test]
         public void AddTransition_AddsCrichtonTransitionObjectOnce()
         {
             var transition = Fixture.Create<CrichtonTransition>();
@@ -77,6 +95,13 @@ namespace Crichton.Representors.Tests
 
             Assert.IsNotNull(result.Transitions.SingleOrDefault(t => t == transition));
 
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AddTransition_AddsTransitionWithNull()
+        {
+            sut.AddTransition(null);
         }
 
         [Test]
@@ -90,6 +115,15 @@ namespace Crichton.Representors.Tests
 
             result.Transitions.Should().ContainSingle(t => t.Rel == rel && t.Uri == uri);
 
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AddTransition_AddsRelWithNull()
+        {
+            var uri = Fixture.Create<string>();
+
+            sut.AddTransition(null, uri);
         }
 
         [Test]
@@ -194,6 +228,24 @@ namespace Crichton.Representors.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AddEmbeddedResource_AddsKeyWithNull()
+        {
+            var resource = Fixture.Create<CrichtonRepresentor>();
+
+            sut.AddEmbeddedResource(null, resource);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void AddEmbeddedResource_AddsEmbeddedWithNull()
+        {
+            var key = Fixture.Create<string>();
+
+            sut.AddEmbeddedResource(key, null);
+        }
+
+        [Test]
         public void SetCollection_SetsCollectionDataWithSelfLinks()
         {
             var examples = Fixture.Create<IList<ExampleDataObject>>();
@@ -211,6 +263,24 @@ namespace Crichton.Representors.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetCollection_SetsCollectionWithNull()
+        {
+            Func<ExampleDataObject, string> selfLinkFunc = e => "self-link-" + e.Id;
+
+            sut.SetCollection(null, selfLinkFunc);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetCollection_SetsSelfLinkFuncWithNull()
+        {
+            var examples = Fixture.Create<IList<ExampleDataObject>>();
+
+            sut.SetCollection(examples, null);
+        }
+
+        [Test]
         public void SetCollection_SetsRepresentors()
         {
             var representors = Fixture.CreateMany<CrichtonRepresentor>().ToList();
@@ -220,6 +290,13 @@ namespace Crichton.Representors.Tests
             var result = sut.ToRepresentor();
 
             CollectionAssert.AreEquivalent(representors, result.Collection);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void SetCollection_SetsRepresentorsWithNull()
+        {
+            sut.SetCollection(null);
         }
     }
 }

--- a/tests/Crichton.Representors.Tests/Serializers/HalSerializerTests.cs
+++ b/tests/Crichton.Representors.Tests/Serializers/HalSerializerTests.cs
@@ -248,6 +248,13 @@ namespace Crichton.Representors.Tests.Serializers
         }
 
         [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Serialize_SetsRepresentorWithNull()
+        {
+            sut.Serialize(null);
+        }
+
+        [Test]
         public void DeserializeToNewBuilder_SetsSelfLinkOnBuilder()
         {
             var href = Fixture.Create<string>();
@@ -689,6 +696,30 @@ namespace Crichton.Representors.Tests.Serializers
 
             Assert.AreEqual(1, calledCollection.Count());
 
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void DeserializeToNewBuilder_SetsMessageWithNull()
+        {
+            sut.DeserializeToNewBuilder(null, builderFactoryMethod);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void DeserializeToNewBuilder_SetsMethodWithNull()
+        {
+            var href = Fixture.Create<string>();
+            var json = @"
+            {{
+                ""_links"": {{
+                    ""self"": {{
+                        ""href"": ""{0}""
+                                }}
+                }}
+            }}";
+
+            var builder = sut.DeserializeToNewBuilder(json, null);
         }
 
     }


### PR DESCRIPTION
@edandersen I added the following minor changes. Please review it.
- Added guard clauses in all public methods.
- Changed access modifiers for `CreateLinkObjectFromTransition` and `GetTransitionFromLinkObject` from public to protected.
