### PR TITLE
[MCC-115083] Client can now create Queries and run IQuerySteps

### DIFF
--- a/src/Crichton.Client/Crichton.Client.csproj
+++ b/src/Crichton.Client/Crichton.Client.csproj
@@ -48,6 +48,9 @@
   <ItemGroup>
     <Compile Include="CrichtonClient.cs" />
     <Compile Include="HypermediaQuery.cs" />
+    <Compile Include="IHypermediaQuery.cs" />
+    <Compile Include="IQueryStep.cs" />
+    <Compile Include="ITransitionRequestor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Crichton.Client/CrichtonClient.cs
+++ b/src/Crichton.Client/CrichtonClient.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+using Crichton.Representors;
 using Crichton.Representors.Serializers;
 
 namespace Crichton.Client
 {
-    public class CrichtonClient
+    public class CrichtonClient : ITransitionRequestor
     {
         public HttpClient HttpClient { get; private set; }
         public ISerializer Serializer { get; private set; }
@@ -18,6 +20,16 @@ namespace Crichton.Client
             HttpClient = httpClient;
             Serializer = serializer;
             BaseUri = baseUri;
+        }
+
+        public IHypermediaQuery CreateQuery()
+        {
+            return new HypermediaQuery();
+        }
+
+        public Task<CrichtonRepresentor> ExecuteQueryAsync(IHypermediaQuery query)
+        {
+            return query.ExecuteAsync(this);
         }
     }
 }

--- a/src/Crichton.Client/HypermediaQuery.cs
+++ b/src/Crichton.Client/HypermediaQuery.cs
@@ -2,10 +2,36 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+using Crichton.Representors;
 
 namespace Crichton.Client
 {
-    public class HypermediaQuery
+    public class HypermediaQuery : IHypermediaQuery
     {
+        public IList<IQueryStep> Steps { get; private set; }
+
+        public HypermediaQuery()
+        {
+            Steps = new List<IQueryStep>();
+        }
+
+        public void AddStep(IQueryStep step)
+        {
+            Steps.Add(step);
+        }
+
+        public async Task<CrichtonRepresentor> ExecuteAsync(ITransitionRequestor requestor)
+        {
+            CrichtonRepresentor representor = null;
+
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (var step in Steps)
+            {
+                representor = await step.ExecuteAsync(representor, requestor);
+            }
+
+            return representor;
+        }
     }
 }

--- a/src/Crichton.Client/IHypermediaQuery.cs
+++ b/src/Crichton.Client/IHypermediaQuery.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Crichton.Representors;
+
+namespace Crichton.Client
+{
+    public interface IHypermediaQuery
+    {
+        IList<IQueryStep> Steps { get; }
+        void AddStep(IQueryStep step);
+        Task<CrichtonRepresentor> ExecuteAsync(ITransitionRequestor requestor);
+    }
+}

--- a/src/Crichton.Client/IQueryStep.cs
+++ b/src/Crichton.Client/IQueryStep.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Crichton.Representors;
+
+namespace Crichton.Client
+{
+    public interface IQueryStep
+    {
+        Task<CrichtonRepresentor> ExecuteAsync(CrichtonRepresentor currentRepresentor, ITransitionRequestor transitionRequestor);
+    }
+}

--- a/src/Crichton.Client/ITransitionRequestor.cs
+++ b/src/Crichton.Client/ITransitionRequestor.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Crichton.Client
+{
+    public interface ITransitionRequestor
+    {
+    }
+}

--- a/tests/Crichton.Client.Tests/Crichton.Client.Tests.csproj
+++ b/tests/Crichton.Client.Tests/Crichton.Client.Tests.csproj
@@ -69,6 +69,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="CrichtonClientTests.cs" />
+    <Compile Include="HypermediaQueryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestWithFixture.cs" />
   </ItemGroup>

--- a/tests/Crichton.Client.Tests/CrichtonClientTests.cs
+++ b/tests/Crichton.Client.Tests/CrichtonClientTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
+using Crichton.Representors;
 using Crichton.Representors.Serializers;
 using NUnit.Framework;
+using Ploeh.AutoFixture;
 using Rhino.Mocks;
 
 namespace Crichton.Client.Tests
@@ -42,5 +45,27 @@ namespace Crichton.Client.Tests
         {
             Assert.AreEqual(serializer, sut.Serializer);
         }
+
+        [Test]
+        public void CreateQuery_ReturnsNewInstanceOfHypermediaQuery()
+        {
+            var result = sut.CreateQuery();
+
+            Assert.IsInstanceOf<HypermediaQuery>(result);
+        }
+
+        [Test]
+        public async Task ExecuteQueryAsync_ExecutesTheQueryAndReturnsTheResult()
+        {
+            var query = MockRepository.GenerateMock<IHypermediaQuery>();
+            var representor = Fixture.Create<CrichtonRepresentor>();
+
+            query.Stub(q => q.ExecuteAsync(sut)).Return(Task.FromResult(representor));
+
+            var result = await sut.ExecuteQueryAsync(query);
+
+            Assert.AreEqual(representor, result);
+        }
+
     }
 }

--- a/tests/Crichton.Client.Tests/HypermediaQueryTests.cs
+++ b/tests/Crichton.Client.Tests/HypermediaQueryTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Crichton.Representors;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using Rhino.Mocks;
+
+namespace Crichton.Client.Tests
+{
+    public class HypermediaQueryTests : TestWithFixture
+    {
+        private IHypermediaQuery sut;
+
+        [SetUp]
+        public void Init()
+        {
+            sut = new HypermediaQuery();
+            Fixture = GetFixture();
+        }
+
+        [Test]
+        public void CTOR_CreatesNewStepsList()
+        {
+            Assert.IsNotNull(sut.Steps);
+        }
+
+        [Test]
+        public void AddStep_AddsStepToList()
+        {
+            var step = Fixture.Create<IQueryStep>();
+
+            sut.AddStep(step);
+
+            CollectionAssert.Contains(sut.Steps, step);
+        }
+
+        [Test]
+        public async Task ExecuteAsync_ReturnsResultOfChainedCallsToSteps()
+        {
+            var requestor = Fixture.Create<ITransitionRequestor>();
+            var step1 = MockRepository.GenerateMock<IQueryStep>();
+            var step1Result = Fixture.Create<CrichtonRepresentor>();
+            step1.Stub(s => s.ExecuteAsync(null, requestor)).Return(Task.FromResult(step1Result));
+
+            var step2 = MockRepository.GenerateMock<IQueryStep>();
+            var step2Result = Fixture.Create<CrichtonRepresentor>();
+            step2.Stub(s => s.ExecuteAsync(step1Result, requestor)).Return(Task.FromResult(step2Result));
+
+            sut.Steps.Add(step1);
+            sut.Steps.Add(step2);
+
+            var result = await sut.ExecuteAsync(requestor);
+
+            Assert.AreEqual(step2Result, result);
+        }
+    }
+}


### PR DESCRIPTION
Foundation work to enable the CrichtonClient class to create HypermediaQuery objects and execute them.

@kenyamat @mdsol/hypermedia-team Please review and merge ASAP.
