### PR TITLE
[MCC-115094] Added HypermediaQueryExtensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tools*/bin/*
 docs/*.html
 tools/*/bin/*
 tools/*/obj/*
+TestResults/*

--- a/src/Crichton.Client/Crichton.Client.csproj
+++ b/src/Crichton.Client/Crichton.Client.csproj
@@ -49,6 +49,7 @@
     <Compile Include="CrichtonClient.cs" />
     <Compile Include="HttpClientTransitionRequestHandler.cs" />
     <Compile Include="HypermediaQuery.cs" />
+    <Compile Include="HypermediaQueryExtensions.cs" />
     <Compile Include="IHypermediaQuery.cs" />
     <Compile Include="QuerySteps\IQueryStep.cs" />
     <Compile Include="ITransitionRequestHandler.cs" />

--- a/src/Crichton.Client/HypermediaQuery.cs
+++ b/src/Crichton.Client/HypermediaQuery.cs
@@ -17,6 +17,11 @@ namespace Crichton.Client
             Steps = new List<IQueryStep>();
         }
 
+        private HypermediaQuery(IEnumerable<IQueryStep> steps)
+        {
+            Steps = steps.ToList();
+        }
+
         public void AddStep(IQueryStep step)
         {
             Steps.Add(step);
@@ -33,6 +38,11 @@ namespace Crichton.Client
             }
 
             return representor;
+        }
+
+        public IHypermediaQuery Clone()
+        {
+            return new HypermediaQuery(this.Steps);
         }
     }
 }

--- a/src/Crichton.Client/HypermediaQueryExtensions.cs
+++ b/src/Crichton.Client/HypermediaQueryExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Crichton.Client.QuerySteps;
+using Crichton.Representors;
+
+namespace Crichton.Client
+{
+    public static class HypermediaQueryExtensions
+    {
+        public static IHypermediaQuery FollowSelf(this IHypermediaQuery hypermediaQuery)
+        {
+            var query = hypermediaQuery.Clone();
+            query.AddStep(new NavigateToSelfLinkQueryStep());
+            return query;
+        }
+
+        public static IHypermediaQuery Follow(this IHypermediaQuery hypermediaQuery, string rel)
+        {
+            var query = hypermediaQuery.Clone();
+            query.AddStep(new NavigateToTransitionQueryStep(rel));
+            return query;
+        }
+
+        public static IHypermediaQuery FollowWithData(this IHypermediaQuery hypermediaQuery, string rel, object data)
+        {
+            var query = hypermediaQuery.Clone();
+            query.AddStep(new PostToTransitionQueryStep(rel, data));
+            return query;
+        }
+
+        public static IHypermediaQuery WithUrl(this IHypermediaQuery hypermediaQuery, string url)
+        {
+            var query = hypermediaQuery.Clone();
+            query.AddStep(new NavigateToRelativeUrlQueryStep(url));
+            return query;
+        }
+
+        public static IHypermediaQuery WithRepresentor(this IHypermediaQuery hypermediaQuery,
+            CrichtonRepresentor representor)
+        {
+            var query = hypermediaQuery.Clone();
+            query.AddStep(new NavigateToRepresentorQueryStep(representor));
+            return query;
+        }
+    }
+}

--- a/src/Crichton.Client/IHypermediaQuery.cs
+++ b/src/Crichton.Client/IHypermediaQuery.cs
@@ -10,5 +10,6 @@ namespace Crichton.Client
         IList<IQueryStep> Steps { get; }
         void AddStep(IQueryStep step);
         Task<CrichtonRepresentor> ExecuteAsync(ITransitionRequestHandler requestHandler);
+        IHypermediaQuery Clone();
     }
 }

--- a/src/Crichton.Client/QuerySteps/NavigateToRelativeUrlQueryStep.cs
+++ b/src/Crichton.Client/QuerySteps/NavigateToRelativeUrlQueryStep.cs
@@ -9,16 +9,16 @@ namespace Crichton.Client.QuerySteps
 {
     public class NavigateToRelativeUrlQueryStep : IQueryStep
     {
-        private string url;
+        public string Url { get; private set; }
 
         public NavigateToRelativeUrlQueryStep(string url)
         {
-            this.url = url;
+            this.Url = url;
         }
 
         public Task<CrichtonRepresentor> ExecuteAsync(CrichtonRepresentor currentRepresentor, ITransitionRequestHandler transitionRequestHandler)
         {
-            var transition = new CrichtonTransition() {Uri = url};
+            var transition = new CrichtonTransition() {Uri = Url};
             return transitionRequestHandler.RequestTransitionAsync(transition);
         }
     }

--- a/src/Crichton.Client/QuerySteps/NavigateToRepresentorQueryStep.cs
+++ b/src/Crichton.Client/QuerySteps/NavigateToRepresentorQueryStep.cs
@@ -9,16 +9,16 @@ namespace Crichton.Client.QuerySteps
 {
     public class NavigateToRepresentorQueryStep : IQueryStep
     {
-        private CrichtonRepresentor representor;
+        public CrichtonRepresentor Representor { get; private set; }
 
         public NavigateToRepresentorQueryStep(CrichtonRepresentor representor)
         {
-            this.representor = representor;
+            this.Representor = representor;
         }
 
         public async Task<CrichtonRepresentor> ExecuteAsync(CrichtonRepresentor currentRepresentor, ITransitionRequestHandler transitionRequestHandler)
         {
-            return representor;
+            return Representor;
         }
     }
 }

--- a/src/Crichton.Client/QuerySteps/NavigateToTransitionQueryStep.cs
+++ b/src/Crichton.Client/QuerySteps/NavigateToTransitionQueryStep.cs
@@ -28,7 +28,7 @@ namespace Crichton.Client.QuerySteps
             return transitionRequestHandler.RequestTransitionAsync(transition);
         }
 
-        internal CrichtonTransition LocateTransition(CrichtonRepresentor currentRepresentor)
+        public CrichtonTransition LocateTransition(CrichtonRepresentor currentRepresentor)
         {
             var transition = currentRepresentor.Transitions.Single(selectionFunc);
             return transition;

--- a/src/Crichton.Client/QuerySteps/PostToTransitionQueryStep.cs
+++ b/src/Crichton.Client/QuerySteps/PostToTransitionQueryStep.cs
@@ -9,24 +9,24 @@ namespace Crichton.Client.QuerySteps
 {
     public class PostToTransitionQueryStep : NavigateToTransitionQueryStep
     {
-        private readonly object data;
+        public object Data { get; private set; }
 
         public PostToTransitionQueryStep(string rel, object data) : base(rel)
         {
-            this.data = data;
+            this.Data = data;
         }
 
         public PostToTransitionQueryStep(Func<CrichtonTransition, bool> transitionSelectorFunc, object data)
             : base(transitionSelectorFunc)
         {
-            this.data = data;
+            this.Data = data;
         }
 
         public Task<CrichtonRepresentor> ExecuteAsync(CrichtonRepresentor currentRepresentor, ITransitionRequestHandler transitionRequestHandler)
         {
             var transition = LocateTransition(currentRepresentor);
 
-            return transitionRequestHandler.RequestTransitionAsync(transition, data);
+            return transitionRequestHandler.RequestTransitionAsync(transition, Data);
         }
     }
 }

--- a/tests/Crichton.Client.Tests/Crichton.Client.Tests.csproj
+++ b/tests/Crichton.Client.Tests/Crichton.Client.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="CrichtonClientTests.cs" />
     <Compile Include="FakeHttpMessageHandler.cs" />
     <Compile Include="HttpClientTransitionRequestHandlerTests.cs" />
+    <Compile Include="HypermediaQueryExtensionsTests.cs" />
     <Compile Include="HypermediaQueryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuerySteps\NavigateToRelativeUrlQueryStepTests.cs" />

--- a/tests/Crichton.Client.Tests/HypermediaQueryExtensionsTests.cs
+++ b/tests/Crichton.Client.Tests/HypermediaQueryExtensionsTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Crichton.Client.QuerySteps;
+using Crichton.Representors;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using Rhino.Mocks;
+
+namespace Crichton.Client.Tests
+{
+    public class HypermediaQueryExtensionsTests : TestWithFixture
+    {
+        private IHypermediaQuery query;
+
+        [SetUp]
+        public void Init()
+        {
+            query = MockRepository.GenerateMock<IHypermediaQuery>();
+            Fixture = GetFixture();
+        }
+
+        [Test]
+        public void FollowSelf_ReturnsClonedVersionOfHypermediaQuery()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            var result = query.FollowSelf();
+
+            Assert.AreSame(cloneQuery, result);
+        }
+
+        [Test]
+        public void FollowSelf_CallsAddStepWithNavigateToSelfLinkQueryStep()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            query.FollowSelf();
+
+            cloneQuery.AssertWasCalled(q => q.AddStep(Arg<NavigateToSelfLinkQueryStep>.Is.TypeOf));
+        }
+
+        [Test]
+        public void Follow_ReturnsClonedVersionOfHypermediaQuery()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var rel = Fixture.Create<string>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            var result = query.Follow(rel);
+
+            Assert.AreSame(cloneQuery, result);
+        }
+
+        [Test]
+        public void Follow_CallsNavigateToTransitionQueryStepWithRel()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var rel = Fixture.Create<string>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            query.Follow(rel);
+
+            var testRepresentor = Fixture.Create<CrichtonRepresentor>();
+            var testTransition = Fixture.Create<CrichtonTransition>();
+            testTransition.Rel = rel;
+            testRepresentor.Transitions.Add(testTransition);
+
+            cloneQuery.AssertWasCalled(q => q.AddStep(Arg<NavigateToTransitionQueryStep>.Matches(a => a.LocateTransition(testRepresentor) == testTransition)));
+        }
+
+        [Test]
+        public void FollowWithData_ReturnsClonedVersionOfHypermediaQuery()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var rel = Fixture.Create<string>();
+            var data = new { id = 1, name = "Chad" };
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            var result = query.FollowWithData(rel, data);
+
+            Assert.AreSame(cloneQuery, result);
+        }
+
+        [Test]
+        public void FollowWithData_CallsNavigateToTransitionQueryStepWithRelAndData()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var rel = Fixture.Create<string>();
+            var data = new { id = 2, name = "Jordi" };
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            query.FollowWithData(rel, data);
+
+            var testRepresentor = Fixture.Create<CrichtonRepresentor>();
+            var testTransition = Fixture.Create<CrichtonTransition>();
+            testTransition.Rel = rel;
+            testRepresentor.Transitions.Add(testTransition);
+
+            cloneQuery.AssertWasCalled(q => q.AddStep(Arg<PostToTransitionQueryStep>.Matches(a => a.LocateTransition(testRepresentor) == testTransition && a.Data == data)));
+        }
+
+        [Test]
+        public void WithUrl_ReturnsClonedVersionOfHypermediaQuery()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var url = Fixture.Create<string>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            var result = query.WithUrl(url);
+
+            Assert.AreSame(cloneQuery, result);
+        }
+
+        [Test]
+        public void WithUrl_AddsNavigateToRelativeUrlQueryStepWithUrl()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var url = Fixture.Create<string>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            query.WithUrl(url);
+
+            cloneQuery.AssertWasCalled(q => q.AddStep(Arg<NavigateToRelativeUrlQueryStep>.Matches(a => a.Url == url)));
+        }
+
+        [Test]
+        public void WithRepresentor_ReturnsClonedVersionOfHypermediaQuery()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var representor = Fixture.Create<CrichtonRepresentor>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            var result = query.WithRepresentor(representor);
+
+            Assert.AreSame(cloneQuery, result);
+        }
+
+
+        [Test]
+        public void WithRepresentor_AddsNavigateToRepresentorQueryStepWithRepresentor()
+        {
+            var cloneQuery = Fixture.Create<IHypermediaQuery>();
+            var representor = Fixture.Create<CrichtonRepresentor>();
+            query.Stub(q => q.Clone()).Return(cloneQuery);
+
+            query.WithRepresentor(representor);
+
+            cloneQuery.AssertWasCalled(
+                q => q.AddStep(Arg<NavigateToRepresentorQueryStep>.Matches(r => r.Representor == representor)));
+        }
+    }
+}

--- a/tests/Crichton.Client.Tests/HypermediaQueryTests.cs
+++ b/tests/Crichton.Client.Tests/HypermediaQueryTests.cs
@@ -57,5 +57,21 @@ namespace Crichton.Client.Tests
 
             Assert.AreEqual(step2Result, result);
         }
+
+        [Test]
+        public void Clone_CreatesReturnsANewQueryWithTheSameSteps()
+        {
+            sut.Steps.AddMany(() => Fixture.Create<IQueryStep>(), Fixture.Create<int>());
+
+            var result = sut.Clone();
+
+            Assert.AreNotEqual(result, sut, "Should be a new IHypermediaQuery");
+            Assert.AreNotSame(result.Steps, sut.Steps, "Should be a new List instance of Steps.");
+
+            Assert.IsInstanceOf<HypermediaQuery>(result);
+
+            CollectionAssert.AreEqual(sut.Steps, result.Steps);
+
+        }
     }
 }


### PR DESCRIPTION
Added extension methods for IHypermediaQuery. Now you can go:

``` csharp
var query = client.CreateQuery().WithRepresentor(representor).Follow("my-rel").FollowWithData("sausages", sausage);
await client.ExecuteQueryAsync(query);
```

@kenyamat @mdsol/hypermedia-team Please review and merge.
