### PR TITLE
[MCC-115100] Added support for Request filters

### DIFF
--- a/src/Crichton.Client/Crichton.Client.csproj
+++ b/src/Crichton.Client/Crichton.Client.csproj
@@ -51,6 +51,7 @@
     <Compile Include="HypermediaQuery.cs" />
     <Compile Include="HypermediaQueryExtensions.cs" />
     <Compile Include="IHypermediaQuery.cs" />
+    <Compile Include="ITransitionRequestFilter.cs" />
     <Compile Include="QuerySteps\IQueryStep.cs" />
     <Compile Include="ITransitionRequestHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
+++ b/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
@@ -49,6 +49,9 @@ namespace Crichton.Client
                 requestMessage.Method = new HttpMethod(transition.Methods.First().ToUpperInvariant());
             }
 
+            // add Accept header
+            requestMessage.Headers.Accept.ParseAdd(Serializer.ContentType);
+
             var result = await HttpClient.SendAsync(requestMessage);
 
             var resultContentString = await result.Content.ReadAsStringAsync();

--- a/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
+++ b/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
@@ -69,6 +69,9 @@ namespace Crichton.Client
 
             var result = await HttpClient.SendAsync(requestMessage);
 
+            // will throw HttpRequestException if the request fails
+            result.EnsureSuccessStatusCode();
+
             var resultContentString = await result.Content.ReadAsStringAsync();
 
             var builder = Serializer.DeserializeToNewBuilder(resultContentString, () => new RepresentorBuilder());

--- a/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
+++ b/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
@@ -72,6 +72,14 @@ namespace Crichton.Client
             // will throw HttpRequestException if the request fails
             result.EnsureSuccessStatusCode();
 
+            if (result.Content.Headers.ContentType.MediaType != Serializer.ContentType)
+            {
+                throw new InvalidOperationException(String.Format("Response from {0} was requested with Accept header {1} but the response was {2}.", 
+                    requestMessage.RequestUri, 
+                    Serializer.ContentType, 
+                    result.Content.Headers.ContentType.MediaType));
+            }
+
             var resultContentString = await result.Content.ReadAsStringAsync();
 
             var builder = Serializer.DeserializeToNewBuilder(resultContentString, () => new RepresentorBuilder());

--- a/src/Crichton.Client/ITransitionRequestFilter.cs
+++ b/src/Crichton.Client/ITransitionRequestFilter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace Crichton.Client
+{
+    public interface ITransitionRequestFilter
+    {
+        void Execute(HttpRequestMessage httpRequestMessage);
+    }
+}

--- a/src/Crichton.Client/ITransitionRequestHandler.cs
+++ b/src/Crichton.Client/ITransitionRequestHandler.cs
@@ -9,6 +9,7 @@ namespace Crichton.Client
 {
     public interface ITransitionRequestHandler
     {
+        void AddRequestFilter(ITransitionRequestFilter filter);
         Task<CrichtonRepresentor> RequestTransitionAsync(CrichtonTransition transition, object toSerializeToJson = null);
     }
 }

--- a/tests/Crichton.Client.Tests/FakeHttpMessageHandler.cs
+++ b/tests/Crichton.Client.Tests/FakeHttpMessageHandler.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +15,8 @@ namespace Crichton.Client.Tests
     {
         public string Response { get; set; }
         public HttpStatusCode ResponseStatusCode { get; set; }
-        public Func<HttpRequestMessage, bool> Condition { get; set; } 
-
+        public Func<HttpRequestMessage, bool> Condition { get; set; }
+        public string ContentType { get; set; }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -38,6 +39,11 @@ namespace Crichton.Client.Tests
                 StatusCode = ResponseStatusCode,
                 Content = httpContent
             };
+
+            if (ContentType != null)
+            {
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue(ContentType);
+            }
 
             return response;
         }

--- a/tests/Crichton.Client.Tests/HttpClientTransitionRequestHandlerTests.cs
+++ b/tests/Crichton.Client.Tests/HttpClientTransitionRequestHandlerTests.cs
@@ -73,6 +73,22 @@ namespace Crichton.Client.Tests
         }
 
         [Test]
+        [ExpectedException(typeof(HttpRequestException))]
+        public async Task RequestTransitionAsync_ThrowsHttpExceptionForNonHttpSuccessCode()
+        {
+            const string relativeUri = "api/sausages/1";
+            var transition = new CrichtonTransition { Uri = relativeUri };
+
+            var combinedUrl = new Uri(baseUri + relativeUri, UriKind.RelativeOrAbsolute);
+
+            messageHandler.Condition = m => m.Method == HttpMethod.Get && m.RequestUri == combinedUrl;
+            messageHandler.Response = "oh no";
+            messageHandler.ResponseStatusCode = HttpStatusCode.InternalServerError;
+
+            await sut.RequestTransitionAsync(transition);
+        }
+
+        [Test]
         public async Task PostTransitionDataAsJsonAsync_PostsJsonRepresentationOfObject()
         {
             var testObject = new { id = 2, name = "bratwurst" };


### PR DESCRIPTION
- Now sends the correct Accept header depending on the chosen serializer
- Now supports adding `ITransitionRequestFilter`s. These can be used for authentication schemes or other systems that need to modify the outgoing messages to include special headers or whatever.

For example, we could add an OAuthTransitionRequestFilter, and register it like:

``` csharp
var client = new CrichtonClient(...etc...);
client.TransitionRequestHandler.AddRequestFilter(new OAuthRequestFilter(params));
```

@mdsol/hypermedia-team @kenyamat Please review and merge.
