### PR TITLE
[MCC-115109] Request URL issue

### DIFF
--- a/src/Crichton.Client/Crichton.Client.nuspec
+++ b/src/Crichton.Client/Crichton.Client.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Crichton.Client</id>
     <title>Crichton Hypermedia API Client library</title>
-    <version>0.2.1-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
+    <version>0.2.2-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
     <authors>Ed Andersen</authors>
     <copyright>Medidata Solutions</copyright>
     <licenseUrl>https://github.com/mdsol/crichton-dotnet/blob/develop/LICENSE.md</licenseUrl>
@@ -15,7 +15,7 @@
     <dependencies>
       <dependency id="Newtonsoft.Json" version="6.0.2" />
       <dependency id="Microsoft.Net.Http" version="2.2.22" />
-      <dependency id="Crichton.Representors" version="0.2.1-alpha" />
+      <dependency id="Crichton.Representors" version="0.2.2-alpha" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
+++ b/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
@@ -21,7 +21,6 @@ namespace Crichton.Client
         {
             if (client == null) { throw new ArgumentNullException("client"); }
             if (client.BaseAddress == null) { throw new ArgumentException("BaseAddress must be set on HttpClient."); }
-            if (!client.BaseAddress.IsAbsoluteUri) { throw new ArgumentException("BaseAddress must be absolute uri."); }
             if (serializer == null) { throw new ArgumentNullException("serializer"); }
 
             HttpClient = client;
@@ -43,7 +42,7 @@ namespace Crichton.Client
 
             var requestMessage = new HttpRequestMessage
             {
-                RequestUri = CreateRequestUri(HttpClient.BaseAddress, transition.Uri)
+                RequestUri = transition.Uri != null ? new Uri(transition.Uri, UriKind.RelativeOrAbsolute) : null,
             };
 
             if (toSerializeToJson != null)
@@ -87,23 +86,6 @@ namespace Crichton.Client
             var builder = Serializer.DeserializeToNewBuilder(resultContentString, () => new RepresentorBuilder());
 
             return builder.ToRepresentor();
-        }
-
-        private static Uri CreateRequestUri(Uri baseUri, string transitionUriString)
-        {
-            if (string.IsNullOrWhiteSpace(transitionUriString))
-            {
-                return baseUri;
-            }
-
-            var transitionUri = new Uri(transitionUriString, UriKind.RelativeOrAbsolute);
-
-            if (transitionUri.IsAbsoluteUri)
-            {
-                return transitionUri;
-            }
-
-            return new Uri(baseUri, transitionUri);
         }
     }
 }

--- a/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
+++ b/src/Crichton.Client/HttpClientTransitionRequestHandler.cs
@@ -21,6 +21,7 @@ namespace Crichton.Client
         {
             if (client == null) { throw new ArgumentNullException("client"); }
             if (client.BaseAddress == null) { throw new ArgumentException("BaseAddress must be set on HttpClient."); }
+            if (!client.BaseAddress.IsAbsoluteUri) { throw new ArgumentException("BaseAddress must be absolute uri."); }
             if (serializer == null) { throw new ArgumentNullException("serializer"); }
 
             HttpClient = client;
@@ -42,7 +43,7 @@ namespace Crichton.Client
 
             var requestMessage = new HttpRequestMessage
             {
-                RequestUri = new Uri(transition.Uri, UriKind.RelativeOrAbsolute)
+                RequestUri = CreateRequestUri(HttpClient.BaseAddress, transition.Uri)
             };
 
             if (toSerializeToJson != null)
@@ -86,6 +87,23 @@ namespace Crichton.Client
             var builder = Serializer.DeserializeToNewBuilder(resultContentString, () => new RepresentorBuilder());
 
             return builder.ToRepresentor();
+        }
+
+        private static Uri CreateRequestUri(Uri baseUri, string transitionUriString)
+        {
+            if (string.IsNullOrWhiteSpace(transitionUriString))
+            {
+                return baseUri;
+            }
+
+            var transitionUri = new Uri(transitionUriString, UriKind.RelativeOrAbsolute);
+
+            if (transitionUri.IsAbsoluteUri)
+            {
+                return transitionUri;
+            }
+
+            return new Uri(baseUri, transitionUri);
         }
     }
 }

--- a/src/Crichton.Client/Properties/AssemblyInfo.cs
+++ b/src/Crichton.Client/Properties/AssemblyInfo.cs
@@ -26,6 +26,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.1")]
-[assembly: AssemblyFileVersionAttribute("0.2.1")]
-[assembly: AssemblyInformationalVersion("0.2.1-alpha")]
+[assembly: AssemblyVersion("0.2.2")]
+[assembly: AssemblyFileVersionAttribute("0.2.2")]
+[assembly: AssemblyInformationalVersion("0.2.2-alpha")]

--- a/src/Crichton.Representors/Crichton.Representors.nuspec
+++ b/src/Crichton.Representors/Crichton.Representors.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Crichton.Representors</id>
     <title>Crichton Hypermedia Representors</title>
-    <version>0.2.1-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
+    <version>0.2.2-alpha</version> <!-- why not just use $version$? Because NuGet 2.8.1 has a bug with PCLs: https://nuget.codeplex.com/workitem/4013 -->
     <authors>Ed Andersen, Kenya Matsumoto</authors>
     <copyright>Medidata Solutions</copyright>
     <licenseUrl>https://github.com/mdsol/crichton-dotnet/blob/develop/LICENSE.md</licenseUrl>

--- a/src/Crichton.Representors/Properties/AssemblyInfo.cs
+++ b/src/Crichton.Representors/Properties/AssemblyInfo.cs
@@ -28,6 +28,6 @@ using System.Security;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.1")]
-[assembly: AssemblyFileVersionAttribute("0.2.1")]
-[assembly: AssemblyInformationalVersion("0.2.1-alpha")]
+[assembly: AssemblyVersion("0.2.2")]
+[assembly: AssemblyFileVersionAttribute("0.2.2")]
+[assembly: AssemblyInformationalVersion("0.2.2-alpha")]

--- a/tests/Crichton.Client.Tests/HttpClientTransitionRequestHandlerTests.cs
+++ b/tests/Crichton.Client.Tests/HttpClientTransitionRequestHandlerTests.cs
@@ -44,14 +44,6 @@ namespace Crichton.Client.Tests
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentException))]
-        public void CTOR_ThrowsInvalidOperationExceptionWhenBaseAddressIsNotAbsoluteUri()
-        {
-            client.BaseAddress = new Uri(string.Format("./{0}", Fixture.Create<string>()), UriKind.Relative);
-            sut = new HttpClientTransitionRequestHandler(client, serializer);
-        }
-
-        [Test]
         [ExpectedException(typeof(ArgumentNullException))]
         public void CTOR_SetsNullHttpClient()
         {

--- a/tools/Crichton.Representors.Benchmark/Crichton.Representors.Benchmark.csproj
+++ b/tools/Crichton.Representors.Benchmark/Crichton.Representors.Benchmark.csproj
@@ -56,7 +56,6 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
-    <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Crichton.Representors\Crichton.Representors.csproj">


### PR DESCRIPTION
@BPONTES, as we discussed, I changed the code which created a request url like the following.
Please review this.  @tkwan-mdsol @mdsol/hypermedia-team

```
var baseAddress = "http://mdsol.com/";
var transitionUri = "./medidations";
var httpClient = new HttpClient() { BaseAddress = new Uri(baseAddress) };
var handler = new HttpClientTransitionRequestHandler(httpClient, new HaleSerializer());
var transition = new CrichtonTransition { Uri = transitionUri };
var representor = handler.RequestTransitionAsync(transition).Result;
```
### case 1. Transition url is null.

```
var baseAddress = "http://mdsol.com/";
var transitionUri = null;
```

=> Use only httpClient.BaseAddress. (http://mdsol.com)
### case 2. Transition url is a relative uri.

```
var baseAddress = "http://mdsol.com/";
var transitionUri = "./medidations";
```

=> Combine httpClient.BaseAddress and transition.Uri (http://mdsol.com/medidations)
### case 3. Transition url is a absolute uri.

```
var baseAddress = "http://mdsol.com/";
var transitionUri = "http://google.com/search";
```

=> Use only transition.Uri (http://google.com/search)
